### PR TITLE
Make client load() idempotent when the database is unchanged

### DIFF
--- a/packages/client/src/BaseClient.ts
+++ b/packages/client/src/BaseClient.ts
@@ -27,20 +27,46 @@ export abstract class BaseClient<S> {
 
   protected abstract getStoredEtag(key: string): Promise<string | null>;
   protected abstract storeEtag(key: string, etag: string): Promise<void>;
+  protected abstract hasCachedDb(): Promise<boolean>;
 
+  /**
+   * Download the database unless the cached copy is verifiably fresh, serving
+   * the cache when the server is unreachable.
+   * @returns whether a new database was downloaded and applied
+   */
   protected async syncIfNeeded(
     url: string,
     key: string,
     apply: (data: ArrayBuffer) => Promise<void>,
     force = false,
-  ): Promise<void> {
-    const storedEtag = force ? null : await this.getStoredEtag(key);
-    const head = await fetch(url, { method: "HEAD" });
-    const remoteEtag = head.headers.get("etag");
+  ): Promise<boolean> {
+    try {
+      const [storedEtag, hasCachedDb, head] = await Promise.all([
+        force ? null : this.getStoredEtag(key),
+        this.hasCachedDb(),
+        fetch(url, { method: "HEAD" }),
+      ]);
+      const remoteEtag = head.headers.get("etag");
 
-    if (force || storedEtag !== remoteEtag) {
-      await apply(await this.fetchDb(url));
-      if (remoteEtag) await this.storeEtag(key, remoteEtag);
+      // a missing remote etag means freshness can't be validated, and a
+      // stored etag proves nothing if the database itself is gone
+      if (force || !remoteEtag || !hasCachedDb || storedEtag !== remoteEtag) {
+        await apply(await this.fetchDb(url));
+        if (remoteEtag) await this.storeEtag(key, remoteEtag);
+        return true;
+      }
+
+      return false;
+    } catch (e) {
+      if (!(await this.hasCachedDb()))
+        throw new Error(
+          `Failed to fetch database and no cached version exists. ${e}`,
+        );
+      console.warn(
+        "data-of-loathing: could not contact server to check for updates. Serving cached database which may be outdated.",
+        e,
+      );
+      return false;
     }
   }
 }

--- a/packages/client/src/browser.ts
+++ b/packages/client/src/browser.ts
@@ -8,27 +8,29 @@ export type Strategy =
   | { strategy: "opfs"; url?: string; force?: boolean }
   | { strategy: "ranged"; url?: string };
 
-async function getOpfsEtag(): Promise<string | null> {
+async function readFromOpfs(filename: string): Promise<string | null> {
   try {
     const root = await navigator.storage.getDirectory();
-    const handle = await root.getFileHandle(".dol-etag");
+    const handle = await root.getFileHandle(filename);
     return (await handle.getFile()).text();
   } catch {
     return null;
   }
 }
 
-async function setOpfsEtag(etag: string): Promise<void> {
-  const root = await navigator.storage.getDirectory();
-  const handle = await root.getFileHandle(".dol-etag", { create: true });
-  const writable = await handle.createWritable();
-  await writable.write(etag);
-  await writable.close();
+async function existsInOpfs(filename: string): Promise<boolean> {
+  try {
+    const root = await navigator.storage.getDirectory();
+    await root.getFileHandle(filename);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function writeToOpfs(
   filename: string,
-  buffer: ArrayBuffer,
+  buffer: ArrayBuffer | string,
 ): Promise<void> {
   const root = await navigator.storage.getDirectory();
   const handle = await root.getFileHandle(filename, { create: true });
@@ -44,23 +46,32 @@ export class Client extends BaseClient<Strategy> {
     super(strategy);
   }
 
-  protected async getStoredEtag(_key: string): Promise<string | null> {
-    return localStorage.getItem(ETAG_KEY);
+  protected async getStoredEtag(key: string): Promise<string | null> {
+    return readFromOpfs(`.${key}`);
   }
 
-  protected async storeEtag(_key: string, etag: string): Promise<void> {
-    localStorage.setItem(ETAG_KEY, etag);
+  protected async storeEtag(key: string, etag: string): Promise<void> {
+    await writeToOpfs(`.${key}`, etag);
+  }
+
+  protected async hasCachedDb(): Promise<boolean> {
+    return existsInOpfs("dol.sqlite");
+  }
+
+  async #teardown(): Promise<void> {
+    await this._orm?.close();
+    this._orm = undefined;
+    this.#dialect?.createDriver().destroy();
+    this.#dialect = undefined;
   }
 
   async load(): Promise<void> {
-    await this._orm?.close();
-    this.#dialect?.createDriver().destroy();
-
     const strategy = this._strategy;
     const url = this._strategy.url ?? DEFAULT_URL;
 
     switch (strategy.strategy) {
       case "ranged": {
+        await this.#teardown();
         this.#dialect = new SqliteWorkerDialect(
           new Worker(new URL("./workers/ranged.js", import.meta.url), {
             type: "module",
@@ -70,37 +81,34 @@ export class Client extends BaseClient<Strategy> {
         break;
       }
       case "opfs": {
+        const { force = false } = strategy;
+
+        const updated = await this.syncIfNeeded(
+          url,
+          ETAG_KEY,
+          async (data) => {
+            // the live worker holds an exclusive lock on the OPFS database
+            // file, so it must be torn down before the file can be replaced
+            await this.#teardown();
+            await writeToOpfs("dol.sqlite", data);
+          },
+          force,
+        );
+
+        if (this._orm && !updated) return;
+
+        await this.#teardown();
         this.#dialect = new SqliteWorkerDialect(
           new Worker(new URL("./workers/opfs.js", import.meta.url), {
             type: "module",
           }),
         );
-        const { force = false } = strategy;
-        const storedEtag = await getOpfsEtag();
-
-        try {
-          const remoteEtag = (await fetch(url, { method: "HEAD" })).headers.get("etag");
-          const effectiveStored = force ? null : storedEtag;
-
-          if (force || effectiveStored !== remoteEtag) {
-            const buffer = await this.fetchDb(url);
-            await writeToOpfs("dol.sqlite", buffer);
-            if (remoteEtag) await setOpfsEtag(remoteEtag);
-          }
-        } catch (e) {
-          if (!storedEtag)
-            throw new Error(`Failed to fetch database and no cached version exists. ${e}`);
-          console.warn(
-            "data-of-loathing: could not contact server to check for updates. Serving cached database which may be outdated.",
-            e,
-          );
-        }
-
         await this.#dialect.loadOpfs("/dol.sqlite");
         break;
       }
       case "memory":
       default: {
+        await this.#teardown();
         this.#dialect = new SqliteWorkerDialect(
           new Worker(new URL("./workers/memory.js", import.meta.url), {
             type: "module",

--- a/packages/client/src/node.test.ts
+++ b/packages/client/src/node.test.ts
@@ -1,0 +1,104 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { Client } from "./node.js";
+
+let cacheDir: string;
+
+vi.mock("env-paths", () => ({
+  default: () => ({ cache: cacheDir }),
+}));
+
+let remoteEtag: string | null;
+let dbBuffer: ArrayBuffer;
+let getCount: number;
+
+beforeEach(async () => {
+  cacheDir = await mkdtemp(join(tmpdir(), "dol-test-"));
+  remoteEtag = '"etag-1"';
+  getCount = 0;
+
+  const dbPath = join(cacheDir, "source.sqlite");
+  const db = new DatabaseSync(dbPath);
+  db.exec("CREATE TABLE placeholder (id INTEGER PRIMARY KEY)");
+  db.close();
+  const bytes = await readFile(dbPath);
+  dbBuffer = bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength,
+  );
+
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (_url: string | URL, init?: RequestInit) => {
+      if (init?.method === "HEAD") {
+        return new Response(null, {
+          headers: remoteEtag === null ? {} : { etag: remoteEtag },
+        });
+      }
+      getCount++;
+      return new Response(dbBuffer.slice(0));
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function getOrm(client: Client) {
+  return (client as unknown as { _orm: unknown })._orm;
+}
+
+test("consecutive loads with unchanged etag reuse the same ORM instance", async () => {
+  const client = new Client();
+  await client.load();
+  const first = getOrm(client);
+
+  await client.load();
+  expect(getOrm(client)).toBe(first);
+  expect(getCount).toBe(1);
+});
+
+test("a changed etag re-initialises the ORM", async () => {
+  const client = new Client();
+  await client.load();
+  const first = getOrm(client);
+
+  remoteEtag = '"etag-2"';
+  await client.load();
+  expect(getOrm(client)).not.toBe(first);
+  expect(getCount).toBe(2);
+});
+
+test("force re-initialises even with an unchanged etag", async () => {
+  const client = new Client({ force: true });
+  await client.load();
+  const first = getOrm(client);
+
+  await client.load();
+  expect(getOrm(client)).not.toBe(first);
+  expect(getCount).toBe(2);
+});
+
+test("downloads the database when the server provides no etag", async () => {
+  remoteEtag = null;
+  const client = new Client();
+  await client.load();
+  expect(getCount).toBe(1);
+
+  await client.load();
+  expect(getCount).toBe(2);
+});
+
+test("re-downloads when the cached database is missing despite a matching etag", async () => {
+  await new Client().load();
+  expect(getCount).toBe(1);
+
+  await rm(join(cacheDir, "dol.sqlite"));
+
+  await new Client().load();
+  expect(getCount).toBe(2);
+});

--- a/packages/client/src/node.ts
+++ b/packages/client/src/node.ts
@@ -16,54 +16,60 @@ export class Client extends BaseClient<Strategy> {
   }
 
   protected async getStoredEtag(key: string): Promise<string | null> {
-    return existsSync(key) ? readFile(key, "utf-8") : null;
+    try {
+      return await readFile(key, "utf-8");
+    } catch {
+      return null;
+    }
   }
 
   protected async storeEtag(key: string, etag: string): Promise<void> {
     await writeFile(key, etag, "utf-8");
   }
 
-  private async resolveDbPath(): Promise<string> {
+  protected async hasCachedDb(): Promise<boolean> {
+    return existsSync(join(this.#cacheDir(), "dol.sqlite"));
+  }
+
+  #cacheDirValue?: string;
+  #cacheDir(): string {
+    return (this.#cacheDirValue ??= envPaths("data-of-loathing").cache);
+  }
+
+  private async resolveDbPath(): Promise<{ path: string; updated: boolean }> {
     const strategy = this._strategy;
     switch (strategy.strategy) {
       case "local":
-        return strategy.path;
+        return { path: strategy.path, updated: false };
 
       default:
       case "url": {
         const { url = DEFAULT_URL, force = false } = strategy;
 
-        const cacheDir = envPaths("data-of-loathing").cache;
+        const cacheDir = this.#cacheDir();
         const dbPath = join(cacheDir, "dol.sqlite");
         const etagPath = join(cacheDir, "etag");
-        await mkdir(cacheDir, { recursive: true });
 
-        try {
-          await this.syncIfNeeded(
-            url,
-            etagPath,
-            async (data) => {
-              await writeFile(dbPath, Buffer.from(data));
-            },
-            force,
-          );
-        } catch (e) {
-          if (!existsSync(dbPath))
-            throw new Error(`Failed to fetch database and no cached version exists. ${e}`);
-          console.warn(
-            "data-of-loathing: could not contact server to check for updates. Serving cached database which may be outdated.",
-            e,
-          );
-        }
+        const updated = await this.syncIfNeeded(
+          url,
+          etagPath,
+          async (data) => {
+            await mkdir(cacheDir, { recursive: true });
+            await writeFile(dbPath, Buffer.from(data));
+          },
+          force,
+        );
 
-        return dbPath;
+        return { path: dbPath, updated };
       }
     }
   }
 
   async load(): Promise<void> {
+    const { path, updated } = await this.resolveDbPath();
+    if (this._orm && !updated) return;
+
     await this._orm?.close();
-    const path = await this.resolveDbPath();
     this._orm = await SqlMikroORM.init({
       driver: SqliteDriver,
       driverOptions: new NodeSqliteDialect(path),


### PR DESCRIPTION
## Problem

`Client.load()` closed and re-initialised MikroORM on every call, even when the etag check showed the database hadn't changed. Long-running servers that call `load()` per request to "ensure loaded" leak memory — eggnet's server grew to 2.4GB RSS this way.

## Changes

- `syncIfNeeded` now reports whether a new database was actually downloaded, and `load()` keeps the existing ORM (and, in the browser, the dialect/worker) when nothing changed. Re-initialisation only happens on first load, `force: true`, or a genuine etag change.
- The browser `opfs` strategy now shares `syncIfNeeded` instead of hand-rolling the etag flow, with the offline-fallback ("serve cached copy when the server is unreachable") folded into the shared method behind an abstract `hasCachedDb()` hook. Its etag storage moved from the (never-written) localStorage hooks to the OPFS `.dol-etag` file it actually used.
- Fixes found along the way:
  - The opfs strategy wrote the new database while the live worker still held an exclusive OPFS lock on it, so updates could silently never apply for the lifetime of a session; the worker is now torn down before the file is replaced.
  - A HEAD response with no etag header used to skip the download entirely (`null === null`), leaving a cold start with no database; a missing remote etag now always downloads.
  - A stored etag is no longer trusted when the cached database file itself has been deleted.

## Tests

New `node.test.ts` covers: unchanged etag reuses the same ORM instance, changed etag re-initialises, `force` re-initialises, no-etag servers still download, and a missing cached database re-downloads despite a matching etag.