### PR TITLE
Add MCP server package

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -8,6 +8,7 @@ on:
   push:
     paths:
       - "packages/client/package.json"
+      - "packages/mcp/package.json"
     branches:
       - main
       - v3
@@ -38,5 +39,34 @@ jobs:
         run: |
           yarn workspace data-of-loathing install
           cd packages/client && npm publish --provenance --tag next
+        env:
+          STATUS: ${{ steps.check.outputs.status }}
+
+  build-mcp:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: corepack enable
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24.x"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Check publish status
+        id: check
+        run: |
+          NEXT_VERSION=$(jq -r '.version' < packages/mcp/package.json)
+          STATUS=$(curl --write-out '%{http_code}\n' --head --silent --output /dev/null https://registry.npmjs.org/data-of-loathing-mcp/$NEXT_VERSION)
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+
+      - name: Publish if necessary
+        if: ${{ steps.check.outputs.status == '404' }}
+        run: |
+          yarn workspaces focus data-of-loathing data-of-loathing-mcp
+          yarn workspace data-of-loathing-mcp build
+          yarn workspace data-of-loathing-mcp pack --out /tmp/mcp.tgz
+          npm publish /tmp/mcp.tgz --provenance --tag next
         env:
           STATUS: ${{ steps.check.outputs.status }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,3 +46,24 @@ jobs:
 
       - name: Test
         run: yarn workspace data-of-loathing-etl test
+
+  test-mcp:
+    runs-on: ubuntu-latest
+    name: Test mcp
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: corepack enable
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24.x"
+
+      - name: Install dependencies
+        run: yarn workspaces focus data-of-loathing data-of-loathing-mcp
+
+      - name: Build client
+        run: yarn workspace data-of-loathing build
+
+      - name: Test
+        run: yarn workspace data-of-loathing-mcp test

--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 This repo contains the infrastructure for serving typed Kingdom of Loathing game data as a queryable SQLite database.
 
-It has three parts:
+It has four parts:
 
 - `packages/etl` - pulls data from [KoLmafia](https://github.com/kolmafia/kolmafia)'s data files and populates the database, running on a schedule to stay current
 - `packages/server` - an Express server that serves the SQLite file with ETag and Range request support
 - `packages/client` - a typed TypeScript client for querying the database, published to npm as [data-of-loathing](https://www.npmjs.com/package/data-of-loathing)
+- `packages/mcp` - an [MCP](https://modelcontextprotocol.io) server exposing the game data to LLM agents, wrapping the client
 
 The public database is hosted at [data.loathers.net](https://data.loathers.net). The client defaults to this endpoint, so most users only need to install the npm package.
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "format": "yarn workspaces foreach --all run format",
     "start": "yarn workspace data-of-loathing-server run start",
+    "mcp": "yarn workspace data-of-loathing-mcp run start",
     "etl": "node --env-file-if-exists .env --import tsx packages/etl/src/populate.ts"
   },
   "private": true,

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -64,6 +64,13 @@ first, or use `src/index.ts` via `tsx` for live development):
   String filters are case-insensitive partial matches; JSON-array fields (e.g.
   `Item.uses`, `Familiar.categories`) match rows whose array includes any of the
   given values.
+  - **Related records travel together.** One-to-one/parent records are always
+    included and filterable via nested filters. A 1:1 table like `Consumable` is
+    just optional extra fields on an item, so `find_item` returns the item's
+    `consumable` inline, and `find_consumable` can filter by
+    `where: { item: { name: "fleetwood mac 'n' cheese" } }` and returns the item
+    alongside. Larger collections (e.g. an item's `monsterDrops`) are opt-in via a
+    `populate` argument.
 - `get_modifiers` — the game modifiers (Muscle, Meat Drop, …) attached to an Item,
   Effect, Skill, Familiar, or Outfit, looked up by name or id.
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,93 @@
+# data-of-loathing-mcp
+
+An [MCP](https://modelcontextprotocol.io) server that exposes Kingdom of Loathing
+game data to LLM agents like Claude. It wraps the
+[`data-of-loathing`](../client) client, so it downloads and ETag-caches the SQLite
+database from [data.loathers.net](https://data.loathers.net) automatically — no
+setup or API key required.
+
+Once connected you can ask things like _"what's the autosell value of a seal
+tooth?"_, _"list combat familiars"_, or _"what modifiers does a Mayonnaise Clinic
+grant?"_ and the agent will query the data directly.
+
+## Add it to Claude
+
+### Claude Code (CLI)
+
+```sh
+claude mcp add data-of-loathing -- npx -y data-of-loathing-mcp@next
+```
+
+Then check it connected with `claude mcp list`.
+
+### Claude Desktop
+
+Open **Settings → Developer → Edit Config** (or edit
+`claude_desktop_config.json` directly) and add:
+
+```json
+{
+  "mcpServers": {
+    "data-of-loathing": {
+      "command": "npx",
+      "args": ["-y", "data-of-loathing-mcp@next"]
+    }
+  }
+}
+```
+
+Restart Claude Desktop. The tools appear under the 🔌 icon.
+
+### From a local checkout
+
+If you are hacking on this repo instead of using the published package, point the
+config at the built entry point (run `yarn workspace data-of-loathing-mcp build`
+first, or use `src/index.ts` via `tsx` for live development):
+
+```json
+{
+  "mcpServers": {
+    "data-of-loathing": {
+      "command": "node",
+      "args": ["/absolute/path/to/data-of-loathing/packages/mcp/dist/index.js"]
+    }
+  }
+}
+```
+
+## Tools
+
+- `list_entities` — list the queryable entities and what each contains.
+- `find_<entity>` — one per core entity (`find_item`, `find_familiar`,
+  `find_monster`, `find_skill`, …). Each accepts a typed `where` filter over that
+  entity's scalar fields, plus `orderBy`, `orderDirection`, `limit`, and `offset`.
+  String filters are case-insensitive partial matches; JSON-array fields (e.g.
+  `Item.uses`, `Familiar.categories`) match rows whose array includes any of the
+  given values.
+- `get_modifiers` — the game modifiers (Muscle, Meat Drop, …) attached to an Item,
+  Effect, Skill, Familiar, or Outfit, looked up by name or id.
+
+## Configuration
+
+Set `DOL_SQLITE_PATH` to point at a local `.sqlite` file instead of downloading
+from data.loathers.net (useful offline or in development):
+
+```json
+{
+  "mcpServers": {
+    "data-of-loathing": {
+      "command": "npx",
+      "args": ["-y", "data-of-loathing-mcp@next"],
+      "env": { "DOL_SQLITE_PATH": "/path/to/dol.sqlite" }
+    }
+  }
+}
+```
+
+## Development
+
+```sh
+yarn workspace data-of-loathing-mcp start   # run over stdio (via tsx)
+yarn workspace data-of-loathing-mcp build   # bundle to dist/ for publishing
+yarn workspace data-of-loathing-mcp test    # vitest
+```

--- a/packages/mcp/eslint.config.mjs
+++ b/packages/mcp/eslint.config.mjs
@@ -1,0 +1,17 @@
+// @ts-check
+import { defineConfig } from "eslint/config";
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export default defineConfig(
+  { ignores: ["dist"] },
+  eslint.configs.recommended,
+  tseslint.configs.recommended,
+  {
+    languageOptions: {
+      parserOptions: {
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+);

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-of-loathing-mcp",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "dist/index.js",
   "type": "module",
   "author": "Sam Gaus <sam@gaus.co.uk>",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "data-of-loathing-mcp",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "type": "module",
+  "author": "Sam Gaus <sam@gaus.co.uk>",
+  "license": "MIT",
+  "bin": "dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "rm -rf dist && tsup",
+    "start": "node --env-file-if-exists ../../.env --import tsx src/index.ts",
+    "format": "prettier --write .",
+    "prepublishOnly": "yarn build",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "data-of-loathing": "workspace:*",
+    "zod": "^3.25.0"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.39.2",
+    "@types/node": "^25.0.2",
+    "env-paths": "^4.0.0",
+    "eslint": "^9.39.2",
+    "prettier": "^3.8.3",
+    "tsup": "^8.5.1",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3",
+    "typescript-eslint": "^8.50.0",
+    "vitest": "^4.1.6"
+  }
+}

--- a/packages/mcp/src/entities.ts
+++ b/packages/mcp/src/entities.ts
@@ -1,0 +1,59 @@
+import {
+  ItemUse,
+  EffectQuality,
+  SkillTag,
+  FamiliarCategory,
+  MonsterElement,
+  MonsterDropCategory,
+  LocationDifficulty,
+  LocationEnvironment,
+  ConsumableQuality,
+} from "data-of-loathing";
+
+/**
+ * The entities we expose as `find_<entity>` tools. This is the "core" set of
+ * game-data entities documented in the client README; the internal `*Modifiers`
+ * entities, `ItemConfiguration`, and `Meta` are deliberately excluded because an
+ * agent rarely wants to query them directly. Modifiers are reachable through the
+ * dedicated `get_modifiers` tool instead.
+ */
+export const CORE_ENTITIES: Record<string, string> = {
+  Item: "Every item in the game, with autosell, tradeability, and use types.",
+  Effect: "Status effects, their quality, and whether they can be removed.",
+  Skill: "Skills, their MP cost, duration, and tags.",
+  Familiar: "Familiars and their category tags.",
+  Monster: "Monsters, their stats, elements, and combat properties.",
+  Zone: "Adventuring zones (groupings of locations).",
+  Location:
+    "Individual adventuring locations, their difficulty and environment.",
+  Path: "Ascension paths.",
+  AscensionClass: "Character classes.",
+  Equipment: "Equipment stats for equippable items.",
+  Consumable:
+    "Food/booze/spleen consumables, their quality and adventure yield.",
+  Concoction: "Crafting recipes.",
+  Outfit: "Outfits and their treats.",
+  FoldGroup: "Groups of items that fold into one another.",
+  ZapGroup: "Groups of items linked by the wand of zapping.",
+  MonsterDrop: "Item drops for monsters, with drop rate and category.",
+  NativeMonster: "Monsters native to a location.",
+  Ingredient: "Crafting ingredients linking items to concoctions.",
+  OutfitTreat: "Trick-or-treat outfit rewards.",
+};
+
+/**
+ * Enum-backed string columns. The database stores these as plain strings, so the
+ * enum association only exists at the TypeScript level — we keep a manual map to
+ * surface the allowed values in tool descriptions. Keyed by `Entity.field`.
+ */
+export const FIELD_ENUMS: Record<string, string[]> = {
+  "Item.uses": Object.values(ItemUse),
+  "Effect.quality": Object.values(EffectQuality),
+  "Skill.tags": Object.values(SkillTag),
+  "Familiar.categories": Object.values(FamiliarCategory),
+  "Monster.element": Object.values(MonsterElement),
+  "MonsterDrop.category": Object.values(MonsterDropCategory),
+  "Location.difficulty": Object.values(LocationDifficulty),
+  "Location.environment": Object.values(LocationEnvironment),
+  "Consumable.quality": Object.values(ConsumableQuality),
+};

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createClient } from "data-of-loathing";
 import { registerTools } from "./tools.js";
+import pkg from "../package.json" with { type: "json" };
 
 async function main() {
   // DOL_SQLITE_PATH points at a local database file (useful offline / in dev).
@@ -15,7 +16,7 @@ async function main() {
 
   const server = new McpServer({
     name: "data-of-loathing",
-    version: "0.0.1",
+    version: pkg.version,
   });
 
   registerTools(server, client);

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,33 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { createClient } from "data-of-loathing";
+import { registerTools } from "./tools.js";
+
+async function main() {
+  // DOL_SQLITE_PATH points at a local database file (useful offline / in dev).
+  // Otherwise the client downloads and ETag-caches dol.sqlite from data.loathers.net.
+  const localPath = process.env.DOL_SQLITE_PATH;
+  const client = localPath
+    ? createClient({ strategy: "local", path: localPath })
+    : createClient();
+
+  await client.load();
+
+  const server = new McpServer({
+    name: "data-of-loathing",
+    version: "0.0.1",
+  });
+
+  registerTools(server, client);
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  // stdout is reserved for the MCP protocol; log to stderr.
+  console.error("data-of-loathing MCP server running on stdio");
+}
+
+main().catch((error) => {
+  console.error("Fatal error starting data-of-loathing MCP server:", error);
+  process.exit(1);
+});

--- a/packages/mcp/src/tools.test.ts
+++ b/packages/mcp/src/tools.test.ts
@@ -1,0 +1,133 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import envPaths from "env-paths";
+import { beforeAll, describe, expect, test } from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { createClient, type Client } from "data-of-loathing";
+import {
+  registerTools,
+  scalarFields,
+  splitWhere,
+  type ScalarField,
+} from "./tools.js";
+import { CORE_ENTITIES } from "./entities.js";
+
+// --- splitWhere (pure, no database) ---------------------------------------
+
+const fields: ScalarField[] = [
+  { name: "name", kind: "string" },
+  { name: "autosell", kind: "number" },
+  { name: "tradeable", kind: "boolean" },
+  { name: "uses", kind: "json" },
+];
+
+test("splitWhere turns string filters into case-insensitive partial matches", () => {
+  const { dbWhere } = splitWhere(fields, { name: "seal" });
+  expect(dbWhere).toEqual({ name: { $like: "%seal%" } });
+});
+
+test("splitWhere passes numbers and booleans through as equality", () => {
+  const { dbWhere } = splitWhere(fields, { autosell: 1, tradeable: true });
+  expect(dbWhere).toEqual({ autosell: 1, tradeable: true });
+});
+
+test("splitWhere pulls JSON-array columns out for post-filtering", () => {
+  const { dbWhere, jsonWhere } = splitWhere(fields, {
+    name: "tooth",
+    uses: ["smith"],
+  });
+  expect(dbWhere).toEqual({ name: { $like: "%tooth%" } });
+  expect(jsonWhere).toEqual({ uses: ["smith"] });
+});
+
+test("splitWhere ignores undefined values", () => {
+  const { dbWhere, jsonWhere } = splitWhere(fields, { name: undefined });
+  expect(dbWhere).toEqual({});
+  expect(jsonWhere).toEqual({});
+});
+
+// --- database-backed tests ------------------------------------------------
+// These use the client's cached database if present. In CI (no cache) they are
+// skipped rather than downloading a multi-megabyte file during unit tests.
+
+const cachedDb = join(envPaths("data-of-loathing").cache, "dol.sqlite");
+const hasDb = existsSync(cachedDb);
+
+describe.skipIf(!hasDb)("with the cached database", () => {
+  let client: Client;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let tools: Record<string, any>;
+
+  beforeAll(async () => {
+    client = createClient({ strategy: "local", path: cachedDb });
+    await client.load();
+    const server = new McpServer({ name: "test", version: "0" });
+    registerTools(server, client);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    tools = (server as any)._registeredTools;
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const call = async (name: string, args: any) => {
+    const result = await tools[name].handler(args, {});
+    return JSON.parse(result.content[0].text);
+  };
+
+  test("registers a find tool per core entity plus helpers", () => {
+    for (const entity of Object.keys(CORE_ENTITIES)) {
+      expect(tools[`find_${entity.toLowerCase()}`]).toBeDefined();
+    }
+    expect(tools["list_entities"]).toBeDefined();
+    expect(tools["get_modifiers"]).toBeDefined();
+    // Internal modifier/pivot entities are not exposed.
+    expect(tools["find_itemmodifiers"]).toBeUndefined();
+    expect(tools["find_meta"]).toBeUndefined();
+  });
+
+  test("scalarFields includes scalar columns and excludes relations", () => {
+    const names = scalarFields(client, "Item").map((f) => f.name);
+    expect(names).toContain("name");
+    expect(names).toContain("autosell");
+    expect(names).toContain("uses");
+    // Relations are excluded.
+    expect(names).not.toContain("equipment");
+    expect(names).not.toContain("monsterDrops");
+  });
+
+  test("classifies the uses column as a JSON array", () => {
+    const uses = scalarFields(client, "Item").find((f) => f.name === "uses");
+    expect(uses?.kind).toBe("json");
+  });
+
+  test("find_item resolves the seal tooth by partial name", async () => {
+    const rows = await call("find_item", { where: { name: "seal tooth" } });
+    const seal = rows.find((r: { name: string }) => r.name === "seal tooth");
+    expect(seal?.autosell).toBe(1);
+  });
+
+  test("find_familiar filters on a JSON-array category", async () => {
+    const rows = await call("find_familiar", {
+      where: { categories: ["combat0"] },
+    });
+    expect(rows.length).toBeGreaterThan(0);
+    expect(
+      rows.every((r: { categories: string[] }) =>
+        r.categories.includes("combat0"),
+      ),
+    ).toBe(true);
+  });
+
+  test("limit caps the number of returned rows", async () => {
+    const rows = await call("find_item", { limit: 3 });
+    expect(rows).toHaveLength(3);
+  });
+
+  test("get_modifiers returns modifiers for a known item", async () => {
+    const result = await call("get_modifiers", {
+      entity: "Item",
+      name: "seal tooth",
+    });
+    expect(Array.isArray(result.modifiers)).toBe(true);
+    expect(result.name).toBe("seal tooth");
+  });
+});

--- a/packages/mcp/src/tools.test.ts
+++ b/packages/mcp/src/tools.test.ts
@@ -20,19 +20,23 @@ const fields: ScalarField[] = [
   { name: "tradeable", kind: "boolean" },
   { name: "uses", kind: "json" },
 ];
+const noRelations = new Set<string>();
 
 test("splitWhere turns string filters into case-insensitive partial matches", () => {
-  const { dbWhere } = splitWhere(fields, { name: "seal" });
+  const { dbWhere } = splitWhere(fields, noRelations, { name: "seal" });
   expect(dbWhere).toEqual({ name: { $like: "%seal%" } });
 });
 
 test("splitWhere passes numbers and booleans through as equality", () => {
-  const { dbWhere } = splitWhere(fields, { autosell: 1, tradeable: true });
+  const { dbWhere } = splitWhere(fields, noRelations, {
+    autosell: 1,
+    tradeable: true,
+  });
   expect(dbWhere).toEqual({ autosell: 1, tradeable: true });
 });
 
 test("splitWhere pulls JSON-array columns out for post-filtering", () => {
-  const { dbWhere, jsonWhere } = splitWhere(fields, {
+  const { dbWhere, jsonWhere } = splitWhere(fields, noRelations, {
     name: "tooth",
     uses: ["smith"],
   });
@@ -40,8 +44,19 @@ test("splitWhere pulls JSON-array columns out for post-filtering", () => {
   expect(jsonWhere).toEqual({ uses: ["smith"] });
 });
 
+test("splitWhere applies partial matching inside nested relation filters", () => {
+  const { dbWhere } = splitWhere(fields, new Set(["item"]), {
+    item: { name: "fleetwood", autosell: 0 },
+  });
+  expect(dbWhere).toEqual({
+    item: { name: { $like: "%fleetwood%" }, autosell: 0 },
+  });
+});
+
 test("splitWhere ignores undefined values", () => {
-  const { dbWhere, jsonWhere } = splitWhere(fields, { name: undefined });
+  const { dbWhere, jsonWhere } = splitWhere(fields, noRelations, {
+    name: undefined,
+  });
   expect(dbWhere).toEqual({});
   expect(jsonWhere).toEqual({});
 });
@@ -129,5 +144,35 @@ describe.skipIf(!hasDb)("with the cached database", () => {
     });
     expect(Array.isArray(result.modifiers)).toBe(true);
     expect(result.name).toBe("seal tooth");
+  });
+
+  test("find_consumable filters by the related item's name and returns it", async () => {
+    const rows = await call("find_consumable", {
+      where: { item: { name: "fleetwood mac 'n' cheese" } },
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].stomach).toBe(6);
+    // The related item travels alongside, so results are no longer anonymous.
+    expect(rows[0].item.name).toBe("fleetwood mac 'n' cheese");
+  });
+
+  test("find_item includes its 1:1 consumable record automatically", async () => {
+    const rows = await call("find_item", {
+      where: { name: "fleetwood mac 'n' cheese" },
+    });
+    const item = rows.find(
+      (r: { name: string }) => r.name === "fleetwood mac 'n' cheese",
+    );
+    expect(item?.consumable?.stomach).toBe(6);
+  });
+
+  test("collections are excluded unless requested via populate", async () => {
+    const [plain] = await call("find_item", { where: { name: "seal tooth" } });
+    expect(plain.monsterDrops).toBeUndefined();
+    const [withDrops] = await call("find_item", {
+      where: { name: "seal tooth" },
+      populate: ["monsterDrops"],
+    });
+    expect(Array.isArray(withDrops.monsterDrops)).toBe(true);
   });
 });

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1,0 +1,282 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { type Client } from "data-of-loathing";
+import { CORE_ENTITIES, FIELD_ENUMS } from "./entities.js";
+
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 200;
+// When a query filters on a JSON-array column we post-filter in JS, so cap how
+// many rows we pull from the database before filtering to avoid unbounded reads.
+const JSON_SCAN_CAP = 2000;
+
+// Entities that carry a `modifiers` relation (the HasModifiers union in the client).
+const MODIFIER_ENTITIES = [
+  "Item",
+  "Effect",
+  "Skill",
+  "Familiar",
+  "Outfit",
+] as const;
+
+type ScalarKind = "string" | "number" | "boolean" | "json";
+
+export type ScalarField = {
+  name: string;
+  kind: ScalarKind;
+  /** Allowed enum values, if this column is backed by an enum. */
+  enumValues?: string[];
+};
+
+function classifyType(
+  columnType: string | undefined,
+  runtimeType: string,
+): ScalarKind {
+  // JSON columns resolve to type "JsonType" / runtimeType "any", so key off the column type.
+  if (columnType === "json") return "json";
+  if (runtimeType === "boolean") return "boolean";
+  if (runtimeType === "number") return "number";
+  return "string";
+}
+
+/**
+ * Split a user-supplied filter into a database WHERE clause and JSON-array
+ * filters that we apply in JS afterwards. String columns become case-insensitive
+ * partial matches; JSON-array columns (uses/tags/categories) are pulled out
+ * because SQLite JSON membership queries are unreliable.
+ */
+export function splitWhere(
+  fields: ScalarField[],
+  where: Record<string, unknown>,
+): { dbWhere: Record<string, unknown>; jsonWhere: Record<string, string[]> } {
+  const jsonFieldNames = new Set(
+    fields.filter((f) => f.kind === "json").map((f) => f.name),
+  );
+  const dbWhere: Record<string, unknown> = {};
+  const jsonWhere: Record<string, string[]> = {};
+  for (const [key, value] of Object.entries(where)) {
+    if (value === undefined) continue;
+    if (jsonFieldNames.has(key)) {
+      jsonWhere[key] = value as string[];
+    } else if (typeof value === "string") {
+      dbWhere[key] = { $like: `%${value}%` };
+    } else {
+      dbWhere[key] = value;
+    }
+  }
+  return { dbWhere, jsonWhere };
+}
+
+/** Read the scalar (non-relation) fields of an entity from MikroORM metadata. */
+export function scalarFields(
+  client: Client,
+  entityName: string,
+): ScalarField[] {
+  // Entity names are dynamic strings; MikroORM's branded EntityName type needs a cast.
+  const meta = client.query.getMetadata().get(entityName as never);
+  return meta.props
+    .filter((prop) => String(prop.kind) === "scalar")
+    .map((prop) => ({
+      name: prop.name,
+      kind: classifyType(prop.columnTypes?.[0], String(prop.runtimeType)),
+      enumValues: FIELD_ENUMS[`${entityName}.${prop.name}`],
+    }));
+}
+
+function describeField(field: ScalarField): string {
+  if (field.enumValues) {
+    const values = field.enumValues.map((v) => `"${v}"`).join(", ");
+    return field.kind === "json"
+      ? `Match rows whose ${field.name} array includes any of: ${values}.`
+      : `One of: ${values}.`;
+  }
+  if (field.kind === "string")
+    return "Case-insensitive partial match (substring).";
+  if (field.kind === "json")
+    return "Match rows whose array includes any of these values.";
+  return "Exact match.";
+}
+
+function whereSchema(fields: ScalarField[]): z.ZodTypeAny {
+  const shape: z.ZodRawShape = {};
+  for (const field of fields) {
+    let schema: z.ZodTypeAny;
+    switch (field.kind) {
+      case "boolean":
+        schema = z.boolean();
+        break;
+      case "number":
+        schema = z.number();
+        break;
+      case "json":
+        schema = z.array(z.string());
+        break;
+      default:
+        schema = z.string();
+    }
+    shape[field.name] = schema.optional().describe(describeField(field));
+  }
+  return z
+    .object(shape)
+    .optional()
+    .describe("Filters to apply (AND-combined).");
+}
+
+type FindArgs = {
+  where?: Record<string, unknown>;
+  orderBy?: string;
+  orderDirection?: "asc" | "desc";
+  limit?: number;
+  offset?: number;
+};
+
+/** Serialize an entity to a plain object of just its scalar fields. */
+function toPlain(fields: ScalarField[], entity: Record<string, unknown>) {
+  const out: Record<string, unknown> = {};
+  for (const field of fields) out[field.name] = entity[field.name];
+  return out;
+}
+
+function textResult(payload: unknown) {
+  return {
+    content: [
+      { type: "text" as const, text: JSON.stringify(payload, null, 2) },
+    ],
+  };
+}
+
+function registerFindTool(
+  server: McpServer,
+  client: Client,
+  entityName: string,
+) {
+  const fields = scalarFields(client, entityName);
+  const scalarNames = fields.map((f) => f.name);
+
+  server.registerTool(
+    `find_${entityName.toLowerCase()}`,
+    {
+      description: `${CORE_ENTITIES[entityName]} Filterable fields: ${scalarNames.join(", ")}.`,
+      inputSchema: {
+        where: whereSchema(fields),
+        orderBy: z
+          .enum(scalarNames as [string, ...string[]])
+          .optional()
+          .describe("Field to sort by."),
+        orderDirection: z.enum(["asc", "desc"]).optional(),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(MAX_LIMIT)
+          .optional()
+          .describe(
+            `Max rows to return (default ${DEFAULT_LIMIT}, max ${MAX_LIMIT}).`,
+          ),
+        offset: z.number().int().min(0).optional(),
+      },
+    },
+    async (rawArgs) => {
+      const args = rawArgs as FindArgs;
+      const em = client.query.fork();
+      const { dbWhere, jsonWhere } = splitWhere(fields, args.where ?? {});
+
+      const limit = args.limit ?? DEFAULT_LIMIT;
+      const offset = args.offset ?? 0;
+      const orderBy = args.orderBy
+        ? { [args.orderBy]: args.orderDirection ?? "asc" }
+        : undefined;
+      const jsonKeys = Object.keys(jsonWhere);
+
+      let rows: Record<string, unknown>[];
+      if (jsonKeys.length === 0) {
+        rows = (await em.find(entityName as never, dbWhere, {
+          orderBy,
+          limit,
+          offset,
+        })) as Record<string, unknown>[];
+      } else {
+        // Pull a bounded set matching the scalar filters, then filter the JSON
+        // arrays in JS (SQLite JSON membership queries are unreliable), then page.
+        const candidates = (await em.find(entityName as never, dbWhere, {
+          orderBy,
+          limit: JSON_SCAN_CAP,
+        })) as Record<string, unknown>[];
+        const matched = candidates.filter((row) =>
+          jsonKeys.every((key) => {
+            const arr = row[key];
+            if (!Array.isArray(arr)) return false;
+            return jsonWhere[key].some((wanted) => arr.includes(wanted));
+          }),
+        );
+        rows = matched.slice(offset, offset + limit);
+      }
+
+      return textResult(rows.map((row) => toPlain(fields, row)));
+    },
+  );
+}
+
+function registerListEntities(server: McpServer) {
+  server.registerTool(
+    "list_entities",
+    {
+      description:
+        "List the queryable game-data entities and what each contains. Use this to discover which find_<entity> tool to call.",
+      inputSchema: {},
+    },
+    async () => textResult(CORE_ENTITIES),
+  );
+}
+
+function registerGetModifiers(server: McpServer, client: Client) {
+  server.registerTool(
+    "get_modifiers",
+    {
+      description:
+        "Get the numeric/game modifiers (e.g. Muscle, Meat Drop, Spooky Damage) attached to an Item, Effect, Skill, Familiar, or Outfit. Look up by exact name or id.",
+      inputSchema: {
+        entity: z
+          .enum(MODIFIER_ENTITIES)
+          .describe("Which entity type to look up."),
+        name: z.string().optional().describe("Exact name of the record."),
+        id: z.number().int().optional().describe("Numeric id of the record."),
+      },
+    },
+    async (rawArgs) => {
+      const args = rawArgs as {
+        entity: (typeof MODIFIER_ENTITIES)[number];
+        name?: string;
+        id?: number;
+      };
+      if (args.name === undefined && args.id === undefined) {
+        return textResult({ error: "Provide either name or id." });
+      }
+      const em = client.query.fork();
+      const where =
+        args.id !== undefined ? { id: args.id } : { name: args.name };
+      const record = (await em.findOne(args.entity as never, where, {
+        populate: ["modifiers"],
+      })) as {
+        name?: string;
+        id?: number;
+        modifiers?: { modifiers?: unknown };
+      } | null;
+
+      if (!record) return textResult({ error: "No matching record found." });
+      return textResult({
+        entity: args.entity,
+        name: record.name,
+        id: record.id,
+        modifiers: record.modifiers?.modifiers ?? [],
+      });
+    },
+  );
+}
+
+export function registerTools(server: McpServer, client: Client) {
+  registerListEntities(server);
+  for (const entityName of Object.keys(CORE_ENTITIES)) {
+    registerFindTool(server, client, entityName);
+  }
+  registerGetModifiers(server, client);
+}

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -27,6 +27,16 @@ export type ScalarField = {
   enumValues?: string[];
 };
 
+type Relation = {
+  name: string;
+  /** The related entity's class name. */
+  target: string;
+  /** True for 1:1 / m:1 (a single related record), false for 1:m / m:n. */
+  toOne: boolean;
+  /** Scalar fields of the target, used to serialize and to build nested filters. */
+  targetFields: ScalarField[];
+};
+
 function classifyType(
   columnType: string | undefined,
   runtimeType: string,
@@ -36,34 +46,6 @@ function classifyType(
   if (runtimeType === "boolean") return "boolean";
   if (runtimeType === "number") return "number";
   return "string";
-}
-
-/**
- * Split a user-supplied filter into a database WHERE clause and JSON-array
- * filters that we apply in JS afterwards. String columns become case-insensitive
- * partial matches; JSON-array columns (uses/tags/categories) are pulled out
- * because SQLite JSON membership queries are unreliable.
- */
-export function splitWhere(
-  fields: ScalarField[],
-  where: Record<string, unknown>,
-): { dbWhere: Record<string, unknown>; jsonWhere: Record<string, string[]> } {
-  const jsonFieldNames = new Set(
-    fields.filter((f) => f.kind === "json").map((f) => f.name),
-  );
-  const dbWhere: Record<string, unknown> = {};
-  const jsonWhere: Record<string, string[]> = {};
-  for (const [key, value] of Object.entries(where)) {
-    if (value === undefined) continue;
-    if (jsonFieldNames.has(key)) {
-      jsonWhere[key] = value as string[];
-    } else if (typeof value === "string") {
-      dbWhere[key] = { $like: `%${value}%` };
-    } else {
-      dbWhere[key] = value;
-    }
-  }
-  return { dbWhere, jsonWhere };
 }
 
 /** Read the scalar (non-relation) fields of an entity from MikroORM metadata. */
@@ -82,6 +64,32 @@ export function scalarFields(
     }));
 }
 
+/**
+ * Read an entity's relations. To-one relations (1:1 and m:1) are treated as
+ * "structured extra fields": a Consumable is really just optional columns on an
+ * Item, so we always pull the related record alongside — in both directions.
+ * Collections (1:m / m:n) are larger and only included on request.
+ */
+export function relationsOf(client: Client, entityName: string): Relation[] {
+  const meta = client.query.getMetadata().get(entityName as never);
+  return (
+    meta.props
+      .filter((prop) => String(prop.kind) !== "scalar")
+      // Skip MikroORM's auto-generated inverse pivot properties (e.g. `X__inverse`).
+      .filter((prop) => !prop.name.includes("__"))
+      .map((prop) => {
+        const kind = String(prop.kind);
+        const target = String(prop.type);
+        return {
+          name: prop.name,
+          target,
+          toOne: kind === "1:1" || kind === "m:1",
+          targetFields: scalarFields(client, target),
+        };
+      })
+  );
+}
+
 function describeField(field: ScalarField): string {
   if (field.enumValues) {
     const values = field.enumValues.map((v) => `"${v}"`).join(", ");
@@ -96,24 +104,43 @@ function describeField(field: ScalarField): string {
   return "Exact match.";
 }
 
-function whereSchema(fields: ScalarField[]): z.ZodTypeAny {
+function fieldSchema(field: ScalarField): z.ZodTypeAny {
+  switch (field.kind) {
+    case "boolean":
+      return z.boolean();
+    case "number":
+      return z.number();
+    case "json":
+      return z.array(z.string());
+    default:
+      return z.string();
+  }
+}
+
+function whereSchema(
+  fields: ScalarField[],
+  toOneRelations: Relation[],
+): z.ZodTypeAny {
   const shape: z.ZodRawShape = {};
   for (const field of fields) {
-    let schema: z.ZodTypeAny;
-    switch (field.kind) {
-      case "boolean":
-        schema = z.boolean();
-        break;
-      case "number":
-        schema = z.number();
-        break;
-      case "json":
-        schema = z.array(z.string());
-        break;
-      default:
-        schema = z.string();
+    shape[field.name] = fieldSchema(field)
+      .optional()
+      .describe(describeField(field));
+  }
+  // Nested filters on to-one relations, e.g. `{ item: { name: "seal tooth" } }`.
+  // Only non-JSON target fields are exposed (JSON membership can't be joined on).
+  for (const relation of toOneRelations) {
+    const nested: z.ZodRawShape = {};
+    for (const field of relation.targetFields) {
+      if (field.kind === "json") continue;
+      nested[field.name] = fieldSchema(field)
+        .optional()
+        .describe(describeField(field));
     }
-    shape[field.name] = schema.optional().describe(describeField(field));
+    shape[relation.name] = z
+      .object(nested)
+      .optional()
+      .describe(`Filter by the related ${relation.target} (e.g. { name }).`);
   }
   return z
     .object(shape)
@@ -127,12 +154,88 @@ type FindArgs = {
   orderDirection?: "asc" | "desc";
   limit?: number;
   offset?: number;
+  populate?: string[];
 };
+
+/** Apply the case-insensitive partial-match transform to nested string filters. */
+function mapNestedStrings(
+  value: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value)) {
+    if (val === undefined) continue;
+    out[key] = typeof val === "string" ? { $like: `%${val}%` } : val;
+  }
+  return out;
+}
+
+/**
+ * Split a user-supplied filter into a database WHERE clause and JSON-array
+ * filters that we apply in JS afterwards. String columns become case-insensitive
+ * partial matches; nested to-one relation filters get the same treatment; JSON-array
+ * columns are pulled out because SQLite JSON membership queries are unreliable.
+ */
+export function splitWhere(
+  fields: ScalarField[],
+  relationNames: Set<string>,
+  where: Record<string, unknown>,
+): { dbWhere: Record<string, unknown>; jsonWhere: Record<string, string[]> } {
+  const jsonFieldNames = new Set(
+    fields.filter((f) => f.kind === "json").map((f) => f.name),
+  );
+  const dbWhere: Record<string, unknown> = {};
+  const jsonWhere: Record<string, string[]> = {};
+  for (const [key, value] of Object.entries(where)) {
+    if (value === undefined) continue;
+    if (relationNames.has(key) && value && typeof value === "object") {
+      dbWhere[key] = mapNestedStrings(value as Record<string, unknown>);
+    } else if (jsonFieldNames.has(key)) {
+      jsonWhere[key] = value as string[];
+    } else if (typeof value === "string") {
+      dbWhere[key] = { $like: `%${value}%` };
+    } else {
+      dbWhere[key] = value;
+    }
+  }
+  return { dbWhere, jsonWhere };
+}
 
 /** Serialize an entity to a plain object of just its scalar fields. */
 function toPlain(fields: ScalarField[], entity: Record<string, unknown>) {
   const out: Record<string, unknown> = {};
   for (const field of fields) out[field.name] = entity[field.name];
+  return out;
+}
+
+/**
+ * Serialize a row: its own scalar fields, every to-one relation (always), and any
+ * requested collections. Populated relations are one level deep — the related
+ * record's own scalar fields only, no further nesting.
+ */
+function serializeRow(
+  fields: ScalarField[],
+  toOneRelations: Relation[],
+  collections: Relation[],
+  requestedCollections: Set<string>,
+  row: Record<string, unknown>,
+) {
+  const out = toPlain(fields, row);
+  for (const relation of toOneRelations) {
+    const related = row[relation.name] as Record<string, unknown> | null;
+    out[relation.name] = related
+      ? toPlain(relation.targetFields, related)
+      : null;
+  }
+  for (const relation of collections) {
+    if (!requestedCollections.has(relation.name)) continue;
+    const collection = row[relation.name] as {
+      getItems?: () => Record<string, unknown>[];
+    } | null;
+    out[relation.name] =
+      collection
+        ?.getItems?.()
+        .map((item) => toPlain(relation.targetFields, item)) ?? [];
+  }
   return out;
 }
 
@@ -151,34 +254,70 @@ function registerFindTool(
 ) {
   const fields = scalarFields(client, entityName);
   const scalarNames = fields.map((f) => f.name);
+  const relations = relationsOf(client, entityName);
+  const toOneRelations = relations.filter((r) => r.toOne);
+  const collections = relations.filter((r) => !r.toOne);
+  const toOneNames = toOneRelations.map((r) => r.name);
+  const collectionNames = collections.map((r) => r.name);
+  // Relations that can appear in `where` (to-one only) for nested filtering.
+  const relationFilterNames = new Set(toOneNames);
+
+  const includedNote =
+    toOneNames.length > 0
+      ? ` Always includes the related ${toOneNames.join(", ")}.`
+      : "";
+  const populateNote =
+    collectionNames.length > 0
+      ? ` Request related collections (${collectionNames.join(", ")}) with populate.`
+      : "";
+
+  const inputSchema: z.ZodRawShape = {
+    where: whereSchema(fields, toOneRelations),
+    orderBy: z
+      .enum(scalarNames as [string, ...string[]])
+      .optional()
+      .describe("Field to sort by."),
+    orderDirection: z.enum(["asc", "desc"]).optional(),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(MAX_LIMIT)
+      .optional()
+      .describe(
+        `Max rows to return (default ${DEFAULT_LIMIT}, max ${MAX_LIMIT}).`,
+      ),
+    offset: z.number().int().min(0).optional(),
+  };
+  if (collectionNames.length > 0) {
+    inputSchema.populate = z
+      .array(z.enum(collectionNames as [string, ...string[]]))
+      .optional()
+      .describe("Related collections to include in the output.");
+  }
 
   server.registerTool(
     `find_${entityName.toLowerCase()}`,
     {
-      description: `${CORE_ENTITIES[entityName]} Filterable fields: ${scalarNames.join(", ")}.`,
-      inputSchema: {
-        where: whereSchema(fields),
-        orderBy: z
-          .enum(scalarNames as [string, ...string[]])
-          .optional()
-          .describe("Field to sort by."),
-        orderDirection: z.enum(["asc", "desc"]).optional(),
-        limit: z
-          .number()
-          .int()
-          .min(1)
-          .max(MAX_LIMIT)
-          .optional()
-          .describe(
-            `Max rows to return (default ${DEFAULT_LIMIT}, max ${MAX_LIMIT}).`,
-          ),
-        offset: z.number().int().min(0).optional(),
-      },
+      description:
+        `${CORE_ENTITIES[entityName]} Put filters in a \`where\` object keyed by field ` +
+        `(${scalarNames.join(", ")}); filter related records with nested filters, ` +
+        `e.g. where: { item: { name: "seal tooth" } }.${includedNote}${populateNote}`,
+      inputSchema,
     },
     async (rawArgs) => {
       const args = rawArgs as FindArgs;
       const em = client.query.fork();
-      const { dbWhere, jsonWhere } = splitWhere(fields, args.where ?? {});
+      const { dbWhere, jsonWhere } = splitWhere(
+        fields,
+        relationFilterNames,
+        args.where ?? {},
+      );
+
+      const requestedCollections = new Set(
+        (args.populate ?? []).filter((name) => collectionNames.includes(name)),
+      );
+      const populate = [...toOneNames, ...requestedCollections];
 
       const limit = args.limit ?? DEFAULT_LIMIT;
       const offset = args.offset ?? 0;
@@ -190,6 +329,7 @@ function registerFindTool(
       let rows: Record<string, unknown>[];
       if (jsonKeys.length === 0) {
         rows = (await em.find(entityName as never, dbWhere, {
+          populate: populate as never,
           orderBy,
           limit,
           offset,
@@ -198,6 +338,7 @@ function registerFindTool(
         // Pull a bounded set matching the scalar filters, then filter the JSON
         // arrays in JS (SQLite JSON membership queries are unreliable), then page.
         const candidates = (await em.find(entityName as never, dbWhere, {
+          populate: populate as never,
           orderBy,
           limit: JSON_SCAN_CAP,
         })) as Record<string, unknown>[];
@@ -211,7 +352,17 @@ function registerFindTool(
         rows = matched.slice(offset, offset + limit);
       }
 
-      return textResult(rows.map((row) => toPlain(fields, row)));
+      return textResult(
+        rows.map((row) =>
+          serializeRow(
+            fields,
+            toOneRelations,
+            collections,
+            requestedCollections,
+            row,
+          ),
+        ),
+      );
     },
   );
 }

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "module": "NodeNext",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -6,6 +6,7 @@
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "strict": true,
+    "resolveJsonModule": true,
     "skipLibCheck": true
   },
   "include": ["src"]

--- a/packages/mcp/tsup.config.ts
+++ b/packages/mcp/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: { index: "src/index.ts" },
+  format: "esm",
+  target: "node22",
+  // dependencies (data-of-loathing, the MCP SDK, zod) stay external and are
+  // installed alongside the published package.
+  dts: false,
+  sourcemap: true,
+  // Executable entry point; make it runnable via `npx data-of-loathing-mcp`.
+  banner: { js: "#!/usr/bin/env node" },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -720,6 +720,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hono/node-server@npm:^1.19.9":
+  version: 1.19.15
+  resolution: "@hono/node-server@npm:1.19.15"
+  peerDependencies:
+    hono: ^4
+  checksum: 10c0/677be66df4d419fa062b1cc31e03d5be03ed9d2bfcabefaeea302c9f8c7145b48daab19da46729161c341fbfc9fedbaac8dac2224bdca73e0a6e0f22d7016740
+  languageName: node
+  linkType: hard
+
 "@humanfs/core@npm:^0.19.1":
   version: 0.19.1
   resolution: "@humanfs/core@npm:0.19.1"
@@ -835,6 +844,39 @@ __metadata:
   peerDependencies:
     "@mikro-orm/core": 7.0.14
   checksum: 10c0/5fd6fde8cf8b13625cd2aff36a331dfca41c2dbb107605d438f0c0620f2578c9ada3881f8aaf8c5626c8309514dc3913d679ef6be9f6a91c31d126f2e09397ab
+  languageName: node
+  linkType: hard
+
+"@modelcontextprotocol/sdk@npm:^1.12.0":
+  version: 1.29.0
+  resolution: "@modelcontextprotocol/sdk@npm:1.29.0"
+  dependencies:
+    "@hono/node-server": "npm:^1.19.9"
+    ajv: "npm:^8.17.1"
+    ajv-formats: "npm:^3.0.1"
+    content-type: "npm:^1.0.5"
+    cors: "npm:^2.8.5"
+    cross-spawn: "npm:^7.0.5"
+    eventsource: "npm:^3.0.2"
+    eventsource-parser: "npm:^3.0.0"
+    express: "npm:^5.2.1"
+    express-rate-limit: "npm:^8.2.1"
+    hono: "npm:^4.11.4"
+    jose: "npm:^6.1.3"
+    json-schema-typed: "npm:^8.0.2"
+    pkce-challenge: "npm:^5.0.0"
+    raw-body: "npm:^3.0.0"
+    zod: "npm:^3.25 || ^4.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  peerDependencies:
+    "@cfworker/json-schema": ^4.1.1
+    zod: ^3.25 || ^4.0
+  peerDependenciesMeta:
+    "@cfworker/json-schema":
+      optional: true
+    zod:
+      optional: false
+  checksum: 10c0/7c4bc339205b1652330cd4e6b121cc859079655f2b9c0506bbb15563ba0d07924bda3d949705530532db7f4d2cb86d633dc8f92bc32803d97c7bece2ac63e29f
   languageName: node
   linkType: hard
 
@@ -1906,6 +1948,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ajv-formats@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "ajv-formats@npm:3.0.1"
+  dependencies:
+    ajv: "npm:^8.0.0"
+  peerDependencies:
+    ajv: ^8.0.0
+  peerDependenciesMeta:
+    ajv:
+      optional: true
+  checksum: 10c0/168d6bca1ea9f163b41c8147bae537e67bd963357a5488a1eaf3abe8baa8eec806d4e45f15b10767e6020679315c7e1e5e6803088dfb84efa2b4e9353b83dd0a
+  languageName: node
+  linkType: hard
+
 "ajv@npm:^6.12.4":
   version: 6.12.6
   resolution: "ajv@npm:6.12.6"
@@ -1915,6 +1971,18 @@ __metadata:
     json-schema-traverse: "npm:^0.4.1"
     uri-js: "npm:^4.2.2"
   checksum: 10c0/41e23642cbe545889245b9d2a45854ebba51cda6c778ebced9649420d9205f2efb39cb43dbc41e358409223b1ea43303ae4839db682c848b891e4811da1a5a71
+  languageName: node
+  linkType: hard
+
+"ajv@npm:^8.0.0, ajv@npm:^8.17.1":
+  version: 8.20.0
+  resolution: "ajv@npm:8.20.0"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.3"
+    fast-uri: "npm:^3.0.1"
+    json-schema-traverse: "npm:^1.0.0"
+    require-from-string: "npm:^2.0.2"
+  checksum: 10c0/5df9a1c8f83863cde1bd3a9ddb426f599718f88e3dc9153616c79fb28e0be455335830d7f21d745576519f057b371352daa31047b6a33d7036fe08777d60cf2a
   languageName: node
   linkType: hard
 
@@ -2520,7 +2588,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.6":
+"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.5, cross-spawn@npm:^7.0.6":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
   dependencies:
@@ -2568,6 +2636,28 @@ __metadata:
     typescript: "npm:^5.9.3"
     typescript-eslint: "npm:^8.50.0"
     vitest: "npm:^4.0.15"
+  languageName: unknown
+  linkType: soft
+
+"data-of-loathing-mcp@workspace:packages/mcp":
+  version: 0.0.0-use.local
+  resolution: "data-of-loathing-mcp@workspace:packages/mcp"
+  dependencies:
+    "@eslint/js": "npm:^9.39.2"
+    "@modelcontextprotocol/sdk": "npm:^1.12.0"
+    "@types/node": "npm:^25.0.2"
+    data-of-loathing: "workspace:*"
+    env-paths: "npm:^4.0.0"
+    eslint: "npm:^9.39.2"
+    prettier: "npm:^3.8.3"
+    tsup: "npm:^8.5.1"
+    tsx: "npm:^4.21.0"
+    typescript: "npm:^5.9.3"
+    typescript-eslint: "npm:^8.50.0"
+    vitest: "npm:^4.1.6"
+    zod: "npm:^3.25.0"
+  bin:
+    data-of-loathing-mcp: dist/index.js
   languageName: unknown
   linkType: soft
 
@@ -3308,6 +3398,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eventsource-parser@npm:^3.0.0, eventsource-parser@npm:^3.0.1":
+  version: 3.1.0
+  resolution: "eventsource-parser@npm:3.1.0"
+  checksum: 10c0/5ab4c6c9a2a042be0b387b6d03810eb580bac4ce90e299ede56458125a97ffe3af8145b2740089fc898a96cfa5aae792ee79f2a06257fba2776b0e7bce037071
+  languageName: node
+  linkType: hard
+
+"eventsource@npm:^3.0.2":
+  version: 3.0.7
+  resolution: "eventsource@npm:3.0.7"
+  dependencies:
+    eventsource-parser: "npm:^3.0.1"
+  checksum: 10c0/c48a73c38f300e33e9f11375d4ee969f25cbb0519608a12378a38068055ae8b55b6e0e8a49c3f91c784068434efe1d9f01eb49b6315b04b0da9157879ce2f67d
+  languageName: node
+  linkType: hard
+
 "evp_bytestokey@npm:^1.0.0, evp_bytestokey@npm:^1.0.3":
   version: 1.0.3
   resolution: "evp_bytestokey@npm:1.0.3"
@@ -3337,6 +3443,18 @@ __metadata:
   version: 3.1.2
   resolution: "exponential-backoff@npm:3.1.2"
   checksum: 10c0/d9d3e1eafa21b78464297df91f1776f7fbaa3d5e3f7f0995648ca5b89c069d17055033817348d9f4a43d1c20b0eab84f75af6991751e839df53e4dfd6f22e844
+  languageName: node
+  linkType: hard
+
+"express-rate-limit@npm:^8.2.1":
+  version: 8.6.0
+  resolution: "express-rate-limit@npm:8.6.0"
+  dependencies:
+    debug: "npm:^4.4.3"
+    ip-address: "npm:^10.2.0"
+  peerDependencies:
+    express: ">= 4.11"
+  checksum: 10c0/cce72e87963d90797ddced59de71046b90ca3ca088ab8e73587b50e812aaefa0b79f5a779743034f3ada01fd27d5c7f82063992a02981c7bc9ac74f8b01bb41a
   languageName: node
   linkType: hard
 
@@ -3394,6 +3512,13 @@ __metadata:
   version: 2.0.6
   resolution: "fast-levenshtein@npm:2.0.6"
   checksum: 10c0/111972b37338bcb88f7d9e2c5907862c280ebf4234433b95bc611e518d192ccb2d38119c4ac86e26b668d75f7f3894f4ff5c4982899afced7ca78633b08287c4
+  languageName: node
+  linkType: hard
+
+"fast-uri@npm:^3.0.1":
+  version: 3.1.4
+  resolution: "fast-uri@npm:3.1.4"
+  checksum: 10c0/f90948821ceb49980f64f89b8216ba498f5957f26035be813526a55b6145d26cbd63ef5618d5205a3292b31edc9c08589749350cd72bd86c7095eb434dceb757
   languageName: node
   linkType: hard
 
@@ -3742,6 +3867,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hono@npm:^4.11.4":
+  version: 4.12.32
+  resolution: "hono@npm:4.12.32"
+  checksum: 10c0/3bb2fc0b042af87202e0cb0e5f77ee5b578684d868e1e321ed3de53e02f1ef02fe700811fa0d2fc765636a217bae7633d552d55934175f3dec6307a1f63f4ecb
+  languageName: node
+  linkType: hard
+
 "http-cache-semantics@npm:^4.1.1":
   version: 4.1.1
   resolution: "http-cache-semantics@npm:4.1.1"
@@ -3862,6 +3994,13 @@ __metadata:
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 10c0/4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
+  languageName: node
+  linkType: hard
+
+"ip-address@npm:^10.2.0":
+  version: 10.3.1
+  resolution: "ip-address@npm:10.3.1"
+  checksum: 10c0/45b1c31e2cc53d6354ea39f276d70c365a9b0332e7ca2140a9ad4cdb7fdb9d73b6a7ec0d8bf19993d8dce7ab636cd86c46c3e417b98db5ccb8c25546fe8c0b17
   languageName: node
   linkType: hard
 
@@ -4048,6 +4187,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jose@npm:^6.1.3":
+  version: 6.2.4
+  resolution: "jose@npm:6.2.4"
+  checksum: 10c0/aaba866d71a8cd5bfd7c2c228367318df99f36318d7c6f1e7bca835c3bdd74ea3fe38783277f7bf7c9703ae24338bb3642a6ccdef6aa54c006d29a9711e6f782
+  languageName: node
+  linkType: hard
+
 "joycon@npm:^3.1.1":
   version: 3.1.1
   resolution: "joycon@npm:3.1.1"
@@ -4084,6 +4230,20 @@ __metadata:
   version: 0.4.1
   resolution: "json-schema-traverse@npm:0.4.1"
   checksum: 10c0/108fa90d4cc6f08243aedc6da16c408daf81793bf903e9fd5ab21983cda433d5d2da49e40711da016289465ec2e62e0324dcdfbc06275a607fe3233fde4942ce
+  languageName: node
+  linkType: hard
+
+"json-schema-traverse@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "json-schema-traverse@npm:1.0.0"
+  checksum: 10c0/71e30015d7f3d6dc1c316d6298047c8ef98a06d31ad064919976583eb61e1018a60a0067338f0f79cabc00d84af3fcc489bd48ce8a46ea165d9541ba17fb30c6
+  languageName: node
+  linkType: hard
+
+"json-schema-typed@npm:^8.0.2":
+  version: 8.0.2
+  resolution: "json-schema-typed@npm:8.0.2"
+  checksum: 10c0/89f5e2fb1495483b705c027203c07277ee6bf2665165ad25a9cb55de5af7f72570326d13d32565180781e4083ad5c9688102f222baed7b353c2f39c1e02b0428
   languageName: node
   linkType: hard
 
@@ -4876,6 +5036,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pkce-challenge@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "pkce-challenge@npm:5.0.1"
+  checksum: 10c0/207f4cb976682f27e8324eb49cf71937c98fbb8341a0b8f6142bc6f664825b30e049a54a21b5c034e823ee3c3d412f10d74bd21de78e17452a6a496c2991f57c
+  languageName: node
+  linkType: hard
+
 "pkg-dir@npm:^5.0.0":
   version: 5.0.0
   resolution: "pkg-dir@npm:5.0.0"
@@ -5084,7 +5251,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"raw-body@npm:^3.0.1":
+"raw-body@npm:^3.0.0, raw-body@npm:^3.0.1":
   version: 3.0.2
   resolution: "raw-body@npm:3.0.2"
   dependencies:
@@ -5126,6 +5293,13 @@ __metadata:
   version: 4.1.2
   resolution: "readdirp@npm:4.1.2"
   checksum: 10c0/60a14f7619dec48c9c850255cd523e2717001b0e179dc7037cfa0895da7b9e9ab07532d324bfb118d73a710887d1e35f79c495fa91582784493e085d18c72c62
+  languageName: node
+  linkType: hard
+
+"require-from-string@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "require-from-string@npm:2.0.2"
+  checksum: 10c0/aaa267e0c5b022fc5fd4eef49d8285086b15f2a1c54b28240fdf03599cbd9c26049fee3eab894f2e1f6ca65e513b030a7c264201e3f005601e80c49fb2937ce2
   languageName: node
   linkType: hard
 
@@ -6646,5 +6820,28 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: 10c0/dceb44c28578b31641e13695d200d34ec4ab3966a5729814d5445b194933c096b7ced71494ce53a0e8820685d1d010df8b2422e5bf2cdea7e469d97ffbea306f
+  languageName: node
+  linkType: hard
+
+"zod-to-json-schema@npm:^3.25.1":
+  version: 3.25.2
+  resolution: "zod-to-json-schema@npm:3.25.2"
+  peerDependencies:
+    zod: ^3.25.28 || ^4
+  checksum: 10c0/dd300554393903022487688af14fbda5c719ba8179702bb55b3aa86318830467f0f7beb7d654036975ac963dc4843b72e59636448bfff9a0608f277bb6a14939
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.25 || ^4.0":
+  version: 4.4.3
+  resolution: "zod@npm:4.4.3"
+  checksum: 10c0/7ea31b558e88f9faf44f31dd185e2e1cbf51fed3081787fb96cc2534749b50c0acfc6da7f0922a7353ed092dd358c7d50c28ea96c94d04af64191bd33152eca3
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.25.0":
+  version: 3.25.76
+  resolution: "zod@npm:3.25.76"
+  checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c
   languageName: node
   linkType: hard


### PR DESCRIPTION
Adds `packages/mcp` (`data-of-loathing-mcp`), a stdio [MCP](https://modelcontextprotocol.io) server that exposes the KoL game data to LLM agents like Claude by wrapping the existing `data-of-loathing` client. No query logic is reimplemented — it reuses the client's MikroORM `EntityManager`, so it inherits the automatic database download + ETag cache.

## Tools

- `list_entities` — discover the queryable entities.
- `find_<entity>` — one per core entity (`find_item`, `find_familiar`, …), auto-generated from MikroORM metadata. Each takes a typed `where` (case-insensitive partial match on strings, JSON-array membership for fields like `uses`/`categories`), `orderBy`/`orderDirection`, and capped `limit`/`offset`. Internal `*Modifiers`/pivot/config entities are excluded.
- `get_modifiers` — game modifiers attached to an Item/Effect/Skill/Familiar/Outfit.

21 tools total. Each call runs on a forked EntityManager.

## Packaging & CI

- Builds to `dist/` via `tsup` with a `node` shebang, so it's runnable via `npx data-of-loathing-mcp`.
- `build-mcp` publish job added to `npm.yml` (version-gated, OIDC + provenance, `next` tag).
- `test-mcp` job added to `test.yml`.
- Published as [`data-of-loathing-mcp@0.0.1`](https://www.npmjs.com/package/data-of-loathing-mcp).

## Adding to Claude

```sh
claude mcp add data-of-loathing -- npx -y data-of-loathing-mcp@next
```

See `packages/mcp/README.md` for Claude Desktop and local-checkout setup.

## Testing

- 11 vitest tests pass (pure `splitWhere` logic + database-backed tests gated on the client's cached DB).
- `tsc`, `eslint`, `prettier` clean.
- Verified end-to-end: a fresh `npm install` from the registry boots the binary and completes an MCP `initialize` + `tools/list` handshake returning all 21 tools.